### PR TITLE
Add ports to container

### DIFF
--- a/pkg/devfile/adapters/docker/component/utils.go
+++ b/pkg/devfile/adapters/docker/component/utils.go
@@ -222,7 +222,14 @@ func (a Adapter) generateAndGetContainerConfig(componentName string, comp versio
 		"alias":     *comp.Alias,
 	}
 
-	containerConfig := a.Client.GenerateContainerConfig(*comp.Image, comp.Command, comp.Args, envVars, containerLabels)
+	// For each endpoint defined in the component in the devfile, add it to the portset for the container
+	portSet := nat.PortSet{}
+	for _, endpoint := range comp.Endpoints {
+		port := fmt.Sprint(*endpoint.Port) + "/tcp"
+		portSet[nat.Port(port)] = struct{}{}
+	}
+
+	containerConfig := a.Client.GenerateContainerConfig(*comp.Image, comp.Command, comp.Args, envVars, containerLabels, portSet)
 	return containerConfig
 }
 

--- a/pkg/lclient/generators.go
+++ b/pkg/lclient/generators.go
@@ -6,13 +6,14 @@ import (
 )
 
 // GenerateContainerConfig creates a containerConfig resource that can be used to create a local Docker container
-func (dc *Client) GenerateContainerConfig(image string, entrypoint []string, cmd []string, envVars []string, labels map[string]string) container.Config {
+func (dc *Client) GenerateContainerConfig(image string, entrypoint []string, cmd []string, envVars []string, labels map[string]string, ports nat.PortSet) container.Config {
 	containerConfig := container.Config{
-		Image:      image,
-		Entrypoint: entrypoint,
-		Cmd:        cmd,
-		Env:        envVars,
-		Labels:     labels,
+		Image:        image,
+		Entrypoint:   entrypoint,
+		Cmd:          cmd,
+		Env:          envVars,
+		Labels:       labels,
+		ExposedPorts: ports,
 	}
 	return containerConfig
 }

--- a/pkg/lclient/generators_test.go
+++ b/pkg/lclient/generators_test.go
@@ -17,6 +17,7 @@ func TestGenerateContainerConfig(t *testing.T) {
 		entrypoint []string
 		cmd        []string
 		envVars    []string
+		portset    nat.PortSet
 		labels     map[string]string
 		want       container.Config
 	}{
@@ -56,9 +57,28 @@ func TestGenerateContainerConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "Case 3: Simple config, adding portset",
+			image:      "docker.io/fake-image:latest",
+			entrypoint: []string{"bash"},
+			cmd:        []string{"tail", "-f", "/dev/null"},
+			portset: nat.PortSet{
+				"8080/tcp": struct{}{},
+				"9080/tcp": struct{}{},
+			},
+			want: container.Config{
+				Image:      "docker.io/fake-image:latest",
+				Entrypoint: []string{"bash"},
+				Cmd:        []string{"tail", "-f", "/dev/null"},
+				ExposedPorts: nat.PortSet{
+					"8080/tcp": struct{}{},
+					"9080/tcp": struct{}{},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
-		config := fakeClient.GenerateContainerConfig(tt.image, tt.entrypoint, tt.cmd, tt.envVars, tt.labels)
+		config := fakeClient.GenerateContainerConfig(tt.image, tt.entrypoint, tt.cmd, tt.envVars, tt.labels, tt.portset)
 		if !reflect.DeepEqual(tt.want, config) {
 			t.Errorf("expected %v, actual %v", tt.want, config)
 		}


### PR DESCRIPTION
This PR updates the `generateAndGetContainerConfig` function to retrieve the ports from the component in the devfile and creates a PortSet from it. Which it then passes it into the `GenerateContainerConfig`

The portSet is a mapping between the internal port and an empty `struct{}{}`. Now, I'm not sure why it has to be `struct{}{}`, but that's how it is, and is what works 😆 

This allows the `odo url create` command to work if the container's dockerfile didn't specify `EXPOSE ["<PORT>"]` commands